### PR TITLE
fix: make 'most current' version NOT include prereleases

### DIFF
--- a/build/index.mjs
+++ b/build/index.mjs
@@ -341,10 +341,13 @@ await activity(`Update version dropdown options`, async (log) => {
   const hugoConf = yaml.parse(hugoYaml)
 
   const uniques = {}
-  RUN.versions.filter(v => v !== 'main').forEach(version => {
-    const mm = majmin(version)
-    if (!uniques.hasOwnProperty(mm)) { uniques[mm] = version }
-  })
+  RUN.versions
+    .filter(v => v !== 'main')
+    .filter(v => semver.prerelease(v) === null)
+    .forEach(version => {
+      const mm = majmin(version)
+      if (!uniques.hasOwnProperty(mm)) { uniques[mm] = version }
+    })
 
   const opts = Object.entries(uniques).map(([majmin, version]) => ({
     version: `v${majmin}`,
@@ -370,7 +373,7 @@ await activity(`Clear '/current' version alias`, async () => {
 })
 
 await activity(`Set '/current' version alias`, async (log) => {
-  const current = RUN.versions[0]
+  const current = RUN.versions.filter(v => semver.prerelease(v) === null)[0]
   const verPath = `${RUN.work}/content/en/${current}/_index.md`
   let content = await fs.readFile(verPath, { encoding: 'utf8' })
 


### PR DESCRIPTION
We did our first "prerelease" release today (i.e. vX.Y.Z-alpha) and saw that the current docs build scripts consider it a valid, production release... as such, it will present as the "most current version" when the version drop down is clicked.

This PR makes sure that the "most recent" version selected will NOT include prerelease versions -- the prerelease versions are still _available_ in the docs (if the version is typed into the URL bar directly) but they will no longer be presented "by default" when the major-minor drop down versions are selected.