### PR TITLE
chore: add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+* @defenseunicorns/pepr
+
+# Additional privileged files
+/CODEOWNERS @jeff-mccoy @daveworth
+/cosign.pub @jeff-mccoy @daveworth
+/LICENSE @jeff-mccoy @austenbryan


### PR DESCRIPTION
This repo does not have a codeowners file. This PR adds one.