### PR TITLE
feat: lower depth limit

### DIFF
--- a/build/index.mjs
+++ b/build/index.mjs
@@ -20,7 +20,7 @@ program
 	.parse(process.argv);
 const opts = program.opts();
 
-const RUN = { cutoff: 3 }; // global state bucket!
+const RUN = { cutoff: 2 }; // global state bucket!
 
 async function activity(label, func) {
 	let log = [];


### PR DESCRIPTION
This PR tightens the depth limit that's used in build. With this change, we'll only include the latest version and the version before. 


For example, the following would omit `0.45` if this PR was brought in.

```
ongoing    : [ '0.47', '0.46', '0.45' ]
  retired    : [
  '0.44', '0.43', '0.[42](https://github.com/defenseunicorns/pepr-docs/actions/runs/14204201273/job/39797943624#step:4:43)', '0.40', '0.39',
  '0.38', '0.37', '0.36', '0.35', '0.34',
  '0.33', '0.32', '0.31', '0.30', '0.29',
  '0.28', '0.27', '0.26', '0.25', '0.24',
  '0.23', '0.22', '0.21', '0.20', '0.19',
  '0.18', '0.17', '0.16', '0.15', '0.14',
  '0.13', '0.12', '0.11', '0.10', '0.9',
  '0.8',  '0.7',  '0.6',  '0.5',  '0.4',
  '0.3',  '0.2',  '0.1'
]
  versions   : [
  'v0.47.0', 'v0.46.3',
  'v0.46.2', 'v0.46.1',
  'v0.46.0', 'v0.[45](https://github.com/defenseunicorns/pepr-docs/actions/runs/14204201273/job/39797943624#step:4:46).1',
  'v0.45.0', 'main'
]
```