### PR TITLE
chore: updated build to remove inline html comments

### DIFF
--- a/build/index.mjs
+++ b/build/index.mjs
@@ -100,7 +100,7 @@ const transformContent = (content) => {
 	// 4. Escape MDX content
 	return result
 		.replaceAll(/\*\*@param\b/g, '**\\@param')
-		.replace(/<!--([\s\S]*?)-->/g, '{/* $1 */}')
+		.replace(/<!--([\s\S]*?)-->/g, '')
 		.replace(/<([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>/g, '&lt;$1&gt;')
 		.replace(/<([^>]*[@!][^>]*)>/g, '&lt;$1&gt;');
 };

--- a/build/index.mjs
+++ b/build/index.mjs
@@ -75,6 +75,16 @@ function convertCallouts(content, filePath) {
 	);
 }
 
+// Helper to remove HTML comments repeatedly until none remain
+function removeHtmlComments(input) {
+	let prev;
+	do {
+		prev = input;
+		input = input.replace(/<!--([\s\S]*?)-->/g, '');
+	} while (input !== prev);
+	return input;
+}
+
 // Content transformation pipeline - all transformations in one place
 const transformContent = (content) => {
 	// 1. Fix image paths
@@ -98,9 +108,8 @@ const transformContent = (content) => {
 	});
 
 	// 4. Escape MDX content
-	return result
+	return removeHtmlComments(result)
 		.replaceAll(/\*\*@param\b/g, '**\\@param')
-		.replace(/<!--([\s\S]*?)-->/g, '')
 		.replace(/<([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>/g, '&lt;$1&gt;')
 		.replace(/<([^>]*[@!][^>]*)>/g, '&lt;$1&gt;');
 };


### PR DESCRIPTION
Remove inline comments during build in `.md` files.  The comments are not necessary in this repo and risk being rendered wrong by Starlight and displayed in prod.  
<img width="702" height="481" alt="image" src="https://github.com/user-attachments/assets/94a971bb-2ec9-43ab-82d7-9aa46fc86275" />
