### PR TITLE
chore: always load starlight versions

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -31,10 +31,10 @@ export default defineConfig({
 			plugins: [
 				...(process.env.CHECK_LINKS ? [starlightLinksValidator()] : []),
 				starlightLlmsTxt(),
-				...(dynamicVersions.length > 0 ? [starlightVersions({
+				starlightVersions({
 					versions: dynamicVersions,
 					current: { label: 'Latest' },
-				})] : []),
+				}),
 			],
 			customCss: ['./src/styles/global.css'],
 			title: 'Pepr',


### PR DESCRIPTION
The conditional in astro config was causing the starlight versions plugin to not load properly. Versions plugin overrides Starlights search function which is why the search UI worked but not the content. Removing the unneeded conditional now allows the version plug in to load fully and search functionality is restored.