### PR TITLE
chore: added dist directory to deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,6 +90,7 @@ jobs:
           git config user.email "actions@github.com"
 
           git add --all
+          git add --force dist/
           if ! git diff-index --quiet HEAD; then
             git commit -m "Auto-deploy docs"
             git push origin "$BRANCH"


### PR DESCRIPTION
 The `dist/` is in .gitignore to keep the main branch clean, but we need to force-add it when deploying to the deploy branch so Netlify can serve all the built files including the pagefind search index.  Fixes broken search functionality caused by the merge of [PR #64](https://github.com/defenseunicorns/pepr-docs/commit/0ae7bfe8e37e97c81d9ed9e7e7d6f5a185b26773).  Previous search fix [PR #73](https://github.com/defenseunicorns/pepr-docs/pull/73) fixed the issue of the search not working locally. This issue appeared to be a separate and inconsistent issue occurring during development.