### PR TITLE
chore: removed legacy functions

### DIFF
--- a/scripts/tests/fix-image-paths.test.mjs
+++ b/scripts/tests/fix-image-paths.test.mjs
@@ -18,18 +18,18 @@ async function getFixImagePathsFunction() {
 describe("fixImagePaths - table", () => {
   const testCases = [
     {
-      name: "should convert _images/pepr-arch.svg to assets path",
-      input: "See the ![architecture](_images/pepr-arch.svg) diagram",
+      name: "should convert _images/pepr-arch.png to assets path",
+      input: "See the ![architecture](_images/pepr-arch.png) diagram",
       expected: "/assets/pepr-arch.png",
     },
     {
-      name: "should not contain original _images/pepr-arch.svg",
-      input: "See the ![architecture](_images/pepr-arch.svg) diagram",
-      expected: "_images/pepr-arch.svg",
+      name: "should not contain original _images/pepr-arch.png",
+      input: "See the ![architecture](_images/pepr-arch.png) diagram",
+      expected: "_images/pepr-arch.png",
     },
     {
-      name: "should convert relative paths to assets",
-      input: "![test](../../../images/test.png)",
+      name: "should convert relative _images paths to assets",
+      input: "![test](../../_images/test.png)",
       expected: "/assets/test.png",
     },
     {
@@ -43,27 +43,27 @@ describe("fixImagePaths - table", () => {
       expected: "/assets/dark.png",
     },
     {
-      name: "should convert _images/pepr-arch.svg in multi-image content",
+      name: "should convert _images/pepr-arch.png in multi-image content",
       input:
-        "![arch](_images/pepr-arch.svg)\n![logo](_images/pepr.png)\n![demo](resources/create-pepr-operator/dark.png)\n![other](../../../images/other.png)",
+        "![arch](_images/pepr-arch.png)\n![logo](_images/pepr.png)\n![demo](resources/create-pepr-operator/dark.png)\n![other](../../_images/other.png)",
       expected: "/assets/pepr-arch.png",
     },
     {
       name: "should convert _images/pepr.png in multi-image content",
       input:
-        "![arch](_images/pepr-arch.svg)\n![logo](_images/pepr.png)\n![demo](resources/create-pepr-operator/dark.png)\n![other](../../../images/other.png)",
+        "![arch](_images/pepr-arch.png)\n![logo](_images/pepr.png)\n![demo](resources/create-pepr-operator/dark.png)\n![other](../../_images/other.png)",
       expected: "/assets/pepr.png",
     },
     {
       name: "should convert resources dark.png in multi-image content",
       input:
-        "![arch](_images/pepr-arch.svg)\n![logo](_images/pepr.png)\n![demo](resources/create-pepr-operator/dark.png)\n![other](../../../images/other.png)",
+        "![arch](_images/pepr-arch.png)\n![logo](_images/pepr.png)\n![demo](resources/create-pepr-operator/dark.png)\n![other](../../_images/other.png)",
       expected: "/assets/dark.png",
     },
     {
       name: "should convert relative other.png in multi-image content",
       input:
-        "![arch](_images/pepr-arch.svg)\n![logo](_images/pepr.png)\n![demo](resources/create-pepr-operator/dark.png)\n![other](../../../images/other.png)",
+        "![arch](_images/pepr-arch.png)\n![logo](_images/pepr.png)\n![demo](resources/create-pepr-operator/dark.png)\n![other](../../_images/other.png)",
       expected: "/assets/other.png",
     },
     {

--- a/scripts/tests/pipeline-integration.test.mjs
+++ b/scripts/tests/pipeline-integration.test.mjs
@@ -7,20 +7,16 @@ async function getTransformContentFunction() {
   const funcMatch = buildScript.match(/const transformContent = \(content\) => \{([\s\S]*?)^\};/m);
   if (funcMatch) {
     try {
-      const hasNumericMatch = buildScript.match(
-        /function hasNumericPrefix\(str\) \{\s*return ([^}]+);\s*\}/,
-      );
       const fixImageMatch = buildScript.match(/function fixImagePaths\(content\) \{([\s\S]*?)^\}/m);
       const removeHtmlMatch = buildScript.match(
         /function removeHtmlComments\(input\) \{([\s\S]*?)^\}/m,
       );
 
-      if (hasNumericMatch && fixImageMatch && removeHtmlMatch) {
+      if (fixImageMatch && removeHtmlMatch) {
         return new Function(
           "content",
           `
 					// Helper functions
-					const hasNumericPrefix = (str) => { return ${hasNumericMatch[1]}; };
 					const fixImagePaths = (content) => { ${fixImageMatch[1]} };
 					const removeHtmlComments = (input) => { ${removeHtmlMatch[1]} };
 
@@ -89,44 +85,44 @@ describe("transformContent", () => {
       expected: "&lt;user@example.com&gt;",
     },
     {
-      name: "should process markdown links with numeric prefixes",
-      input: "[Getting Started](1_getting-started/README.md)",
+      name: "should process markdown links and strip README.md",
+      input: "[Getting Started](getting-started/README.md)",
       expected: "[Getting Started](getting-started)",
     },
     {
       name: "should fix image paths in complex content",
       input:
-        "# Documentation\n\n<!-- This is a comment -->\n![arch](_images/pepr-arch.svg)\n\nCheck out this video: https://example.com/demo.mp4\n\n[Getting Started](1_getting-started/README.md)\n\n**@param** config The configuration object\n\nContact: <admin@example.com>",
+        "# Documentation\n\n<!-- This is a comment -->\n![arch](_images/pepr-arch.svg)\n\nCheck out this video: https://example.com/demo.mp4\n\n[Getting Started](getting-started/README.md)\n\n**@param** config The configuration object\n\nContact: <admin@example.com>",
       expected: "/assets/pepr-arch.png",
     },
     {
       name: "should transform video in complex content",
       input:
-        "# Documentation\n\n<!-- This is a comment -->\n![arch](_images/pepr-arch.svg)\n\nCheck out this video: https://example.com/demo.mp4\n\n[Getting Started](1_getting-started/README.md)\n\n**@param** config The configuration object\n\nContact: <admin@example.com>",
+        "# Documentation\n\n<!-- This is a comment -->\n![arch](_images/pepr-arch.svg)\n\nCheck out this video: https://example.com/demo.mp4\n\n[Getting Started](getting-started/README.md)\n\n**@param** config The configuration object\n\nContact: <admin@example.com>",
       expected: '<video class="td-content" controls',
     },
     {
       name: "should fix links in complex content",
       input:
-        "# Documentation\n\n<!-- This is a comment -->\n![arch](_images/pepr-arch.svg)\n\nCheck out this video: https://example.com/demo.mp4\n\n[Getting Started](1_getting-started/README.md)\n\n**@param** config The configuration object\n\nContact: <admin@example.com>",
+        "# Documentation\n\n<!-- This is a comment -->\n![arch](_images/pepr-arch.svg)\n\nCheck out this video: https://example.com/demo.mp4\n\n[Getting Started](getting-started/README.md)\n\n**@param** config The configuration object\n\nContact: <admin@example.com>",
       expected: "[Getting Started](getting-started)",
     },
     {
       name: "should escape @param in complex content",
       input:
-        "# Documentation\n\n<!-- This is a comment -->\n![arch](_images/pepr-arch.svg)\n\nCheck out this video: https://example.com/demo.mp4\n\n[Getting Started](1_getting-started/README.md)\n\n**@param** config The configuration object\n\nContact: <admin@example.com>",
+        "# Documentation\n\n<!-- This is a comment -->\n![arch](_images/pepr-arch.svg)\n\nCheck out this video: https://example.com/demo.mp4\n\n[Getting Started](getting-started/README.md)\n\n**@param** config The configuration object\n\nContact: <admin@example.com>",
       expected: "**\\@param**",
     },
     {
       name: "should escape email in complex content",
       input:
-        "# Documentation\n\n<!-- This is a comment -->\n![arch](_images/pepr-arch.svg)\n\nCheck out this video: https://example.com/demo.mp4\n\n[Getting Started](1_getting-started/README.md)\n\n**@param** config The configuration object\n\nContact: <admin@example.com>",
+        "# Documentation\n\n<!-- This is a comment -->\n![arch](_images/pepr-arch.svg)\n\nCheck out this video: https://example.com/demo.mp4\n\n[Getting Started](getting-started/README.md)\n\n**@param** config The configuration object\n\nContact: <admin@example.com>",
       expected: "&lt;admin@example.com&gt;",
     },
     {
       name: "should not contain comments in complex content",
       input:
-        "# Documentation\n\n<!-- This is a comment -->\n![arch](_images/pepr-arch.svg)\n\nCheck out this video: https://example.com/demo.mp4\n\n[Getting Started](1_getting-started/README.md)\n\n**@param** config The configuration object\n\nContact: <admin@example.com>",
+        "# Documentation\n\n<!-- This is a comment -->\n![arch](_images/pepr-arch.svg)\n\nCheck out this video: https://example.com/demo.mp4\n\n[Getting Started](getting-started/README.md)\n\n**@param** config The configuration object\n\nContact: <admin@example.com>",
       expected: "<!-- This is a comment -->",
     },
   ];

--- a/scripts/tests/process-content-links.test.mjs
+++ b/scripts/tests/process-content-links.test.mjs
@@ -4,9 +4,6 @@ import * as fs from "node:fs/promises";
 async function getProcessContentLinksFunction() {
   const buildScript = await fs.readFile("scripts/index.mjs", "utf8");
 
-  const hasNumericMatch = buildScript.match(
-    /function hasNumericPrefix\(str\) \{\s*return ([^}]+);\s*\}/,
-  );
   const fixImageMatch = buildScript.match(/function fixImagePaths\(content\) \{([\s\S]*?)^\}/m);
   const removeHtmlMatch = buildScript.match(
     /function removeHtmlComments\(input\) \{([\s\S]*?)^\}/m,
@@ -20,7 +17,6 @@ async function getProcessContentLinksFunction() {
   );
 
   if (
-    hasNumericMatch &&
     fixImageMatch &&
     removeHtmlMatch &&
     transformContentMatch &&
@@ -32,7 +28,6 @@ async function getProcessContentLinksFunction() {
       "file",
       `
 			const path = { basename: (filePath) => filePath.split('/').pop() };
-			const hasNumericPrefix = (str) => { return ${hasNumericMatch[1]}; };
 			const fixImagePaths = (content) => { ${fixImageMatch[1]} };
 			const removeHtmlComments = (input) => { ${removeHtmlMatch[1]} };
 			const transformContent = (content) => { ${transformContentMatch[1]} };


### PR DESCRIPTION
Removed functions no longer needed since the naming structure of Pepr Core docs has changed.  Left comments for future simplification once v 1.0.2 has been retired.  