### PR TITLE
chore: add transform function to remap root markdown files

### DIFF
--- a/scripts/index.mjs
+++ b/scripts/index.mjs
@@ -310,7 +310,12 @@ const writeVersionLandingPage = async (version, verdir, core) => {
     let idxBody = await fs.readFile(`${core}/README.md`, "utf8");
     idxBody = idxBody.replaceAll("](./docs/", "](./");
 
-    idxBody = transformContent(idxBody).replaceAll(".md)", "/");
+    idxBody = transformContent(idxBody)
+      .replaceAll(".md)", "/")
+      // Remap root community files to their correct docs site paths (from ROOT_MD_MAPPINGS)
+      .replaceAll("](./code-of-conduct)", "](./contribute/code-of-conduct)")
+      .replaceAll("](./security)", "](./community/security)")
+      .replaceAll("](./support)", "](./community/support)");
 
     await fs.writeFile(idxMd, [idxFront, idxBody].join("\n"), "utf8");
     log.push(["dst", idxMd]);

--- a/scripts/index.mjs
+++ b/scripts/index.mjs
@@ -312,7 +312,7 @@ const writeVersionLandingPage = async (version, verdir, core) => {
 
     idxBody = transformContent(idxBody)
       .replaceAll(".md)", "/")
-      // Remap root community files to their correct docs site paths (from ROOT_MD_MAPPINGS)
+      // Remap root community files to their correct doc-site paths (from ROOT_MD_MAPPINGS)
       .replaceAll("](./code-of-conduct)", "](./contribute/code-of-conduct)")
       .replaceAll("](./security)", "](./community/security)")
       .replaceAll("](./support)", "](./community/support)");


### PR DESCRIPTION
Code of Conduct badge on Pepr GitHub [Readme](https://github.com/defenseunicorns/pepr/blob/main/README.md) was broken.  Transform content function was added to the doc site to remap the link so it works on GitHub and docs.pepr.dev. 

Relates to [Pepr #3071](https://github.com/defenseunicorns/pepr/pull/3071)